### PR TITLE
fix: pin base image as py3.11 due to pillow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM python:3-alpine
+FROM python:3.11-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY requirements.txt /usr/src/app/
 
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev git && \ 
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev git \
+            tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev \
+            lcms2-dev libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev \
+            libimagequant-dev libxcb-dev libpng-dev && \ 
 pip install --no-cache-dir -r requirements.txt && \ 
 apk --purge del .build-deps
 


### PR DESCRIPTION
The pillow isn't compatible with python > 3.11
Also there're bunch of different image format dependences for the packages.